### PR TITLE
Check homepage

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -21,6 +21,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 const whitelist = get(appPackage, "react-dotenv.whitelist", []);
 
 /**
+ * Check for custom homepage (basepath)
+ * More Info: https://create-react-app.dev/docs/deployment/#building-for-relative-paths
+ */
+const homepage = get(appPackage, "homepage");
+
+/**
  * Remove all environment variables
  * not included in the whitelist
  */
@@ -58,9 +64,9 @@ function patchIndexHtml(html) {
   let $ = cheerio.load(html);
 
   if ($("script#react-dotenv").length) {
-    $("script#react-dotenv").attr("src", "./env.js");
+    $("script#react-dotenv").attr("src", `${homepage ? homepage : "."}/env.js`);
   } else {
-    $("head").append('\t<script id="react-dotenv" src="./env.js"></script>\n\t');
+    $("head").append(`\t<script id="react-dotenv" src="${homepage ? homepage : "."}/env.js"></script>\n\t`);
   }
 
   return prettier.format($.html(), { parser: "html" });

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ const whitelist = get(appPackage, "react-dotenv.whitelist", []);
  * Check for custom homepage (basepath)
  * More Info: https://create-react-app.dev/docs/deployment/#building-for-relative-paths
  */
-const homepage = get(appPackage, "homepage");
+const homepage = get(appPackage, "homepage", ".");
 
 /**
  * Remove all environment variables
@@ -64,9 +64,9 @@ function patchIndexHtml(html) {
   let $ = cheerio.load(html);
 
   if ($("script#react-dotenv").length) {
-    $("script#react-dotenv").attr("src", `${homepage ? homepage : "."}/env.js`);
+    $("script#react-dotenv").attr("src", `${homepage}/env.js`);
   } else {
-    $("head").append(`\t<script id="react-dotenv" src="${homepage ? homepage : "."}/env.js"></script>\n\t`);
+    $("head").append(`\t<script id="react-dotenv" src="${homepage}/env.js"></script>\n\t`);
   }
 
   return prettier.format($.html(), { parser: "html" });


### PR DESCRIPTION
I added a check for homepage to support paths other than relative paths for the env.js file injection. [`homepage`](https://create-react-app.dev/docs/deployment/#building-for-relative-paths) is the common way to change the basepath of a project in create react app. 