### PR TITLE
Fix base url

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -21,16 +21,18 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 const whitelist = get(appPackage, "react-dotenv.whitelist", []);
 
 /**
- * Check for custom homepage (basepath)
- * More Info: https://create-react-app.dev/docs/deployment/#building-for-relative-paths
- */
-const homepage = removeTrailingSlashes(get(appPackage, "homepage", "."));
-
-/**
  * Remove all environment variables
  * not included in the whitelist
  */
 const env = whitelist.length ? pick(process.env, whitelist) : process.env;
+
+/**
+ * Check for custom homepage (basepath)
+ * More Info: https://create-react-app.dev/docs/deployment/#building-for-relative-paths
+ */
+const homepage = get(appPackage, "homepage", "/");
+
+const baseUrl = removeTrailingSlashes(env.PUBLIC_URL || env.REACT_APP_BASE_URL || homepage);
 
 const envFile = `window.env = ${JSON.stringify(env, null, 2)};`;
 
@@ -64,18 +66,18 @@ function patchIndexHtml(html) {
   let $ = cheerio.load(html);
 
   if ($("script#react-dotenv").length) {
-    $("script#react-dotenv").attr("src", `${homepage}/env.js`);
+    $("script#react-dotenv").attr("src", `${baseUrl}/env.js`);
   } else {
-    $("head").append(`\t<script id="react-dotenv" src="${homepage}/env.js"></script>\n\t`);
+    $("head").append(`\t<script id="react-dotenv" src="${baseUrl}/env.js"></script>\n\t`);
   }
 
   return prettier.format($.html(), { parser: "html" });
 }
 
 function removeTrailingSlashes(url) {
-  let result = url
+  let result = url;
   while (result.length && result[result.length-1] === '/') {
-    result=result.slice(0, -1)
+    result=result.slice(0, -1);
   }
-  return result
+  return result;
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ const whitelist = get(appPackage, "react-dotenv.whitelist", []);
  * Check for custom homepage (basepath)
  * More Info: https://create-react-app.dev/docs/deployment/#building-for-relative-paths
  */
-const homepage = get(appPackage, "homepage", ".");
+const homepage = removeTrailingSlashes(get(appPackage, "homepage", "."));
 
 /**
  * Remove all environment variables
@@ -70,4 +70,12 @@ function patchIndexHtml(html) {
   }
 
   return prettier.format($.html(), { parser: "html" });
+}
+
+function removeTrailingSlashes(url) {
+  let result = url
+  while (result.length && result[result.length-1] === '/') {
+    result=result.slice(0, -1)
+  }
+  return result
 }


### PR DESCRIPTION
The current solution of using the value of "homepage" in package.json doesn't really work well on multiple environments.
Typically one would run a project under localhost on dev machines and changing locally package.json is not a great solution.
There would be no need to have a full url as a base url, in fact, just using "/env.js" would do for every environment.
To keep all options open, I think this should do:

    The base url is built picking, in order, the first available setting among:
    * PUBLIC_URL in env
    * REACT_APP_BASE_URL in env
    * homepage value in package.json
    * a root relative url: '/'

Also, any trailing slashes are removed from whatever the base url ends up being, before appending '/env.js', so that the final url doesn't end up being something like 'http://my-base-url//env.js'